### PR TITLE
Feature/rework sequencer implementation

### DIFF
--- a/Assets/CuttingRoom/Scripts/Core/NarrativeObjects/NarrativeObject.cs
+++ b/Assets/CuttingRoom/Scripts/Core/NarrativeObjects/NarrativeObject.cs
@@ -77,6 +77,10 @@ namespace CuttingRoom
             InitialiseVariableStore(forceRefresh: true);
         }
 
+        /// <summary>
+        /// Ensure variable store is correctly initialised and contains required variables.
+        /// </summary>
+        /// <param name="forceRefresh"></param>
         public void InitialiseVariableStore(bool forceRefresh = false)
         {
             if (VariableStore == null)
@@ -90,11 +94,14 @@ namespace CuttingRoom
             }
             if (!VariableStore.Variables.ContainsKey(hasPlayedTagName))
             {
-                BoolVariable falseVariable = VariableStore.GetOrAddVariable<BoolVariable>(hasPlayedTagName, Variable.VariableCategory.SystemDefined, false) as BoolVariable;
+                BoolVariable hasPlayedVariable = VariableStore.GetOrAddVariable<BoolVariable>(hasPlayedTagName, Variable.VariableCategory.SystemDefined, false) as BoolVariable;
                 VariableStore.RefreshDictionary();
             }
         }
 
+        /// <summary>
+        /// Updates event handlers for all triggers and variables
+        /// </summary>
         public virtual void OnValidate()
         {
             if (EndTriggers != null)

--- a/Assets/CuttingRoom/Scripts/Core/NarrativeObjects/Processing/GraphNarrativeObjectProcessing.cs
+++ b/Assets/CuttingRoom/Scripts/Core/NarrativeObjects/Processing/GraphNarrativeObjectProcessing.cs
@@ -45,7 +45,8 @@ namespace CuttingRoom
             GraphNarrativeObject.PreProcess();
 
             // Process from the defined root.
-            contentCoroutine = GraphNarrativeObject.StartCoroutine(sequencer.SequenceNarrativeObject(GraphNarrativeObject.rootNarrativeObject, graphCancellationToken.Token));
+            Sequencer subSequencer = new(GraphNarrativeObject.rootNarrativeObject);
+            //contentCoroutine = subSequencer.Start(graphCancellationToken.Token);            
 
             // Process the base functionality, output selection.
             yield return base.Process(sequencer, cancellationToken);

--- a/Assets/CuttingRoom/Scripts/Core/NarrativeObjects/Processing/GraphNarrativeObjectProcessing.cs
+++ b/Assets/CuttingRoom/Scripts/Core/NarrativeObjects/Processing/GraphNarrativeObjectProcessing.cs
@@ -21,6 +21,8 @@ namespace CuttingRoom
         /// </summary>
         private Sequencer sequencer = null;
 
+        private Sequencer subSequencer = null;
+
         /// <summary>
         /// Ctor.
         /// </summary>
@@ -45,8 +47,9 @@ namespace CuttingRoom
             GraphNarrativeObject.PreProcess();
 
             // Process from the defined root.
-            Sequencer subSequencer = new(GraphNarrativeObject.rootNarrativeObject);
-            //contentCoroutine = subSequencer.Start(graphCancellationToken.Token);            
+            subSequencer = new(GraphNarrativeObject.rootNarrativeObject);
+            subSequencer.Start(graphCancellationToken.Token);
+            contentCoroutine = GraphNarrativeObject.StartCoroutine(subSequencer.WaitForSequenceComplete());
 
             // Process the base functionality, output selection.
             yield return base.Process(sequencer, cancellationToken);

--- a/Assets/CuttingRoom/Scripts/Core/NarrativeObjects/Processing/GroupNarrativeObjectProcessing.cs
+++ b/Assets/CuttingRoom/Scripts/Core/NarrativeObjects/Processing/GroupNarrativeObjectProcessing.cs
@@ -20,6 +20,8 @@ namespace CuttingRoom
 		/// </summary>
 		private Sequencer sequencer = null;
 
+		private Sequencer subSequencer = null;
+
 		/// <summary>
 		/// Ctor.
 		/// </summary>
@@ -43,7 +45,7 @@ namespace CuttingRoom
 
             GroupNarrativeObject.PreProcess();
 
-			yield return GroupNarrativeObject.GroupSelectionDecisionPoint.Process(sequencer, OnSelection);
+			yield return GroupNarrativeObject.GroupSelectionDecisionPoint.Process(OnSelection);
 
 			yield return base.Process(sequencer, cancellationToken);
 
@@ -59,8 +61,10 @@ namespace CuttingRoom
 		{
 			if (selection != null)
 			{
-				contentCoroutine = GroupNarrativeObject.StartCoroutine(sequencer.SequenceNarrativeObject(selection, groupCancellationToken.Token));
-			}
+                subSequencer = new(selection);
+                subSequencer.Start(groupCancellationToken.Token);
+				contentCoroutine = narrativeObject.StartCoroutine(subSequencer.WaitForSequenceComplete());
+            }
 			// Nothing asynchronous needed here so return null.
 			yield return null;
         }

--- a/Assets/CuttingRoom/Scripts/Core/NarrativeObjects/Processing/GroupNarrativeObjectProcessing.cs
+++ b/Assets/CuttingRoom/Scripts/Core/NarrativeObjects/Processing/GroupNarrativeObjectProcessing.cs
@@ -61,9 +61,12 @@ namespace CuttingRoom
 		{
 			if (selection != null)
 			{
-                subSequencer = new(selection);
+				if (subSequencer == null)
+				{
+					subSequencer = new(selection);
+				}
                 subSequencer.Start(groupCancellationToken.Token);
-				contentCoroutine = narrativeObject.StartCoroutine(subSequencer.WaitForSequenceComplete());
+				contentCoroutine = GroupNarrativeObject.StartCoroutine(subSequencer.WaitForSequenceComplete());
             }
 			// Nothing asynchronous needed here so return null.
 			yield return null;

--- a/Assets/CuttingRoom/Scripts/Core/NarrativeObjects/Processing/LayerNarrativeObjectProcessing.cs
+++ b/Assets/CuttingRoom/Scripts/Core/NarrativeObjects/Processing/LayerNarrativeObjectProcessing.cs
@@ -22,6 +22,8 @@ namespace CuttingRoom
         /// </summary>
         private Sequencer sequencer = null;
 
+        private Sequencer subSequencer = null;
+
         private List<Coroutine> secondaryLayerCoroutines = new List<Coroutine>();
 
         /// <summary>
@@ -86,8 +88,9 @@ namespace CuttingRoom
                 {
                     if (layerRoot == LayerNarrativeObject.primaryLayerRootNarrativeObject)
                     {
-                        Sequencer subSequencer = new(layerRoot);
-                        //contentCoroutine = subSequencer.Start(layerCancellationToken.Token);
+                        subSequencer = new(layerRoot);
+                        subSequencer.Start(layerCancellationToken.Token);
+                        contentCoroutine = LayerNarrativeObject.StartCoroutine(subSequencer.WaitForSequenceComplete());
                     }
                     else
                     {

--- a/Assets/CuttingRoom/Scripts/Core/NarrativeObjects/Processing/LayerNarrativeObjectProcessing.cs
+++ b/Assets/CuttingRoom/Scripts/Core/NarrativeObjects/Processing/LayerNarrativeObjectProcessing.cs
@@ -94,7 +94,7 @@ namespace CuttingRoom
                     }
                     else
                     {
-                        secondaryLayerCoroutines.Add(sequencer.ProcessNarrativeObject(layerRoot, layerCancellationToken.Token));
+                        secondaryLayerCoroutines.Add(sequencer.SubSequenceNarrativeObject(layerRoot, layerCancellationToken.Token));
                     }
                 }    
             }

--- a/Assets/CuttingRoom/Scripts/Core/NarrativeObjects/Processing/NarrativeObjectProcessing.cs
+++ b/Assets/CuttingRoom/Scripts/Core/NarrativeObjects/Processing/NarrativeObjectProcessing.cs
@@ -66,12 +66,12 @@ namespace CuttingRoom
                 }
 
                 yield return MonitorForProcessComplete();
+                yield return cancellationMonitor;
 
                 foreach (var endTrig in endTriggers)
                 {
                     narrativeObject.StopCoroutine(endTrig);
                 }
-                yield return cancellationMonitor;
             }
 
 
@@ -84,11 +84,11 @@ namespace CuttingRoom
             }
             else
             {
-                yield return narrativeObject.OutputSelectionDecisionPoint.Process(sequencer, OnOutputSelection);
+                yield return narrativeObject.OutputSelectionDecisionPoint.Process(OnOutputSelection);
 
                 if (selectedOutputNarrativeObject != null)
                 {
-                    yield return narrativeObject.StartCoroutine(sequencer.SequenceNarrativeObject(selectedOutputNarrativeObject, cancellationToken));
+                    sequencer.SequenceNarrativeObject(selectedOutputNarrativeObject, cancellationToken);
                 }
             }
 

--- a/Assets/CuttingRoom/Scripts/Core/NarrativeSpace.cs
+++ b/Assets/CuttingRoom/Scripts/Core/NarrativeSpace.cs
@@ -4,6 +4,7 @@ using UnityEngine;
 using CuttingRoom.VariableSystem;
 using CuttingRoom.VariableSystem.Variables;
 using System;
+using UnityEditor;
 
 namespace CuttingRoom
 {
@@ -35,10 +36,23 @@ namespace CuttingRoom
         [SerializeField]
         private VariableStore globalVariableStore = null;
 
+        private Sequencer sequencer = null;
+
+        public Sequencer Sequencer { get => sequencer; }
+
         /// <summary>
         /// Get accessor for the global variable store.
         /// </summary>
         public VariableStore GlobalVariableStore { get { return globalVariableStore; } set { globalVariableStore = value; } }
+
+        public void Start()
+        {
+            if (Application.isPlaying || EditorApplication.isPlaying)
+            {
+                sequencer = new(rootNarrativeObject, this, true);
+                sequencer.Start();
+            }
+        }
 
 #if UNITY_EDITOR
         public void Awake()

--- a/Assets/CuttingRoom/Scripts/Core/NarrativeSpace.cs
+++ b/Assets/CuttingRoom/Scripts/Core/NarrativeSpace.cs
@@ -60,6 +60,9 @@ namespace CuttingRoom
             InitialiseVariableStore();
         }
 
+        /// <summary>
+        /// Ensure variable store is correctly initialised and contains required variables.
+        /// </summary>
         public void InitialiseVariableStore()
         {
             if (globalVariableStore == null)
@@ -80,6 +83,9 @@ namespace CuttingRoom
 
         public event Action OnChanged;
 
+        /// <summary>
+        /// Updates event handlers for all variables
+        /// </summary>
         public virtual void OnValidate()
         {
             if (globalVariableStore != null)

--- a/Assets/CuttingRoom/Scripts/Core/ProcessingEndTriggers/VariableEndTrigger.cs
+++ b/Assets/CuttingRoom/Scripts/Core/ProcessingEndTriggers/VariableEndTrigger.cs
@@ -62,11 +62,11 @@ namespace CuttingRoom
                 case VariableStoreLocation.Global:
 
                     // Find the sequencer.
-                    Sequencer sequencer = FindObjectOfType<Sequencer>();
+                    NarrativeSpace narrativeSpace = FindObjectOfType<NarrativeSpace>();
 
-                    if (sequencer != null)
+                    if (narrativeSpace != null)
                     {
-                        variable = sequencer.NarrativeSpace.GlobalVariableStore.GetVariable<Variable>(variableName);
+                        variable = narrativeSpace.GlobalVariableStore.GetVariable<Variable>(variableName);
                     }
 
                     break;

--- a/Assets/CuttingRoom/Scripts/Core/Sequencer.cs
+++ b/Assets/CuttingRoom/Scripts/Core/Sequencer.cs
@@ -40,9 +40,11 @@ namespace CuttingRoom
 
         private Queue<SequencedNarrativeObject> narrativeObjectSequenceQueue = new Queue<SequencedNarrativeObject>();
 
-        public NarrativeObject CurrentNarrativeObject = null;
+        public NarrativeObject CurrentNarrativeObjectForSequence { get; private set; } = null;
 
-        public List<NarrativeObject> SequenceHistory = new();
+        static public NarrativeObject CurrentNarrativeObject { get; private set; } = null;
+
+        static public List<NarrativeObject> SequenceHistory { get; private set; } = new();
 
         public bool SequenceComplete { get; private set; } = false;
 
@@ -98,10 +100,19 @@ namespace CuttingRoom
 
             while (narrativeObjectSequenceQueue.Count > 0)
             {
+#if UNITY_EDITOR
+                string history = "";
+                foreach (var narrativeObject in SequenceHistory)
+                {
+                    history = $"{history}{narrativeObject.name} -> ";
+                }
+                Debug.Log(history);
+#endif
                 SequencedNarrativeObject sequencedNarrativeObject = narrativeObjectSequenceQueue.Dequeue();
                 CurrentNarrativeObject = sequencedNarrativeObject.narrativeObject;
+                CurrentNarrativeObjectForSequence = sequencedNarrativeObject.narrativeObject;
+                SequenceHistory.Add(CurrentNarrativeObjectForSequence);
                 yield return ProcessNarrativeObject(sequencedNarrativeObject.narrativeObject, sequencedNarrativeObject.cancellationToken);
-                SequenceHistory.Add(CurrentNarrativeObject);
             }
 
             SequenceComplete = true;

--- a/Assets/CuttingRoom/Scripts/Core/Sequencer.cs
+++ b/Assets/CuttingRoom/Scripts/Core/Sequencer.cs
@@ -77,11 +77,6 @@ namespace CuttingRoom
             }
         }
 
-        public IEnumerator WaitForSequenceStart()
-        {
-            yield return new WaitUntil(() => { return sequenceCoroutine != null; });
-        }
-
         public IEnumerator WaitForSequenceComplete()
         {
             if (sequenceCoroutine != null)

--- a/Assets/CuttingRoom/Scripts/DecisionPoints/DecisionPoint.cs
+++ b/Assets/CuttingRoom/Scripts/DecisionPoints/DecisionPoint.cs
@@ -37,43 +37,49 @@ namespace CuttingRoom
 		/// </summary>
 		protected OnSelectionCallback onSelection = null;
 
-		public abstract IEnumerator Process(Sequencer sequencer, OnSelectionCallback onSelection);
-        public abstract IEnumerator Process(Sequencer sequencer, OnMultiSelectionCallback onSelection);
+		public abstract IEnumerator Process(OnSelectionCallback onSelection);
+        public abstract IEnumerator Process(OnMultiSelectionCallback onSelection);
 
-        protected List<NarrativeObject> ProcessConstraints(Sequencer sequencer, List<Constraint> decisionPointConstraints)
+        protected List<NarrativeObject> ProcessConstraints(List<Constraint> decisionPointConstraints)
         {
 			// All candidates are an option to begin with.
 			List<NarrativeObject> candidatesMatchingConstraints = new List<NarrativeObject>(candidates);
 
-			// Iterate candidates and check them against decision point constraints.
-			for (int candidateCount = candidatesMatchingConstraints.Count - 1; candidateCount >= 0; candidateCount--)
+			NarrativeSpace narrativeSpace = FindObjectOfType<NarrativeSpace>();
+
+			if (narrativeSpace != null)
 			{
-				NarrativeObject candidate = candidatesMatchingConstraints[candidateCount];
 
-				// For each constraint.
-				for (int constraintCount = 0; constraintCount < decisionPointConstraints.Count; constraintCount++)
+				// Iterate candidates and check them against decision point constraints.
+				for (int candidateCount = candidatesMatchingConstraints.Count - 1; candidateCount >= 0; candidateCount--)
 				{
-					Constraint constraint = decisionPointConstraints[constraintCount];
+					NarrativeObject candidate = candidatesMatchingConstraints[candidateCount];
 
-					if (!constraint.Evaluate(sequencer, sequencer.NarrativeSpace, candidate))
+					// For each constraint.
+					for (int constraintCount = 0; constraintCount < decisionPointConstraints.Count; constraintCount++)
 					{
-						candidatesMatchingConstraints.Remove(candidate);
+						Constraint constraint = decisionPointConstraints[constraintCount];
+
+						if (!constraint.Evaluate(narrativeSpace, candidate))
+						{
+							candidatesMatchingConstraints.Remove(candidate);
+						}
 					}
 				}
-			}
 
-			for (int candidateCount = candidatesMatchingConstraints.Count - 1; candidateCount >= 0; candidateCount--)
-			{
-				NarrativeObject candidate = candidatesMatchingConstraints[candidateCount];
-
-				// For each constraint on the candidate.
-				for (int candidateConstraintCount = 0; candidateConstraintCount < candidate.constraints.Count; candidateConstraintCount++)
+				for (int candidateCount = candidatesMatchingConstraints.Count - 1; candidateCount >= 0; candidateCount--)
 				{
-					Constraint candidateConstraint = candidate.constraints[candidateConstraintCount];
+					NarrativeObject candidate = candidatesMatchingConstraints[candidateCount];
 
-					if (!candidateConstraint.Evaluate(sequencer, sequencer.NarrativeSpace, candidate))
+					// For each constraint on the candidate.
+					for (int candidateConstraintCount = 0; candidateConstraintCount < candidate.constraints.Count; candidateConstraintCount++)
 					{
-						candidatesMatchingConstraints.Remove(candidate);
+						Constraint candidateConstraint = candidate.constraints[candidateConstraintCount];
+
+						if (!candidateConstraint.Evaluate(narrativeSpace, candidate))
+						{
+							candidatesMatchingConstraints.Remove(candidate);
+						}
 					}
 				}
 			}

--- a/Assets/CuttingRoom/Scripts/DecisionPoints/GroupSelectionDecisionPoint.cs
+++ b/Assets/CuttingRoom/Scripts/DecisionPoints/GroupSelectionDecisionPoint.cs
@@ -60,7 +60,7 @@ namespace CuttingRoom
 			terminationMethodContainer.Init();
 		}
 
-		public override IEnumerator Process(Sequencer sequencer, OnSelectionCallback onSelection)
+		public override IEnumerator Process(OnSelectionCallback onSelection)
 		{
 			if (selectionMethodContainer.Initialised && terminationMethodContainer.Initialised)
 			{
@@ -85,7 +85,7 @@ namespace CuttingRoom
 							// Store the number of selections made before invoking the process method.
 							int preProcessSelectionCount = selections.Count;
 
-							List<NarrativeObject> validCandidates = ProcessConstraints(sequencer, constraints);
+							List<NarrativeObject> validCandidates = ProcessConstraints(constraints);
 
 							MethodContainer.Args args = new MethodContainer.Args { onSelection = OnSelection, candidates = validCandidates };
 
@@ -107,7 +107,7 @@ namespace CuttingRoom
 			}
 		}
 
-		public override IEnumerator Process(Sequencer sequencer, OnMultiSelectionCallback onSelection)
+		public override IEnumerator Process(OnMultiSelectionCallback onSelection)
 		{
 			// Not implemented
 			throw new NotImplementedException("Process() not implemented for multi selection on groups.");

--- a/Assets/CuttingRoom/Scripts/DecisionPoints/LayerSelectionDecisionPoint.cs
+++ b/Assets/CuttingRoom/Scripts/DecisionPoints/LayerSelectionDecisionPoint.cs
@@ -11,15 +11,15 @@ namespace CuttingRoom
     public class LayerSelectionDecisionPoint : DecisionPoint
     {
 
-        public override IEnumerator Process(Sequencer sequencer, OnSelectionCallback onSelection)
+        public override IEnumerator Process(OnSelectionCallback onSelection)
         {
             // Not implemented
             throw new NotImplementedException("Process() not implemented for multi selection on groups.");
         }
 
-        public override IEnumerator Process(Sequencer sequencer, OnMultiSelectionCallback onSelection)
+        public override IEnumerator Process(OnMultiSelectionCallback onSelection)
         {
-            var validCandidates = ProcessConstraints(sequencer, constraints);
+            var validCandidates = ProcessConstraints(constraints);
             if (validCandidates != null)
             {
                 yield return onSelection.Invoke(validCandidates);

--- a/Assets/CuttingRoom/Scripts/DecisionPoints/OutputSelectionDecisionPoint.cs
+++ b/Assets/CuttingRoom/Scripts/DecisionPoints/OutputSelectionDecisionPoint.cs
@@ -39,7 +39,7 @@ namespace CuttingRoom
         /// </summary>
         /// <param name="onSelection"></param>
         /// <returns></returns>
-        public override IEnumerator Process(Sequencer sequencer, OnSelectionCallback onSelection)
+        public override IEnumerator Process(OnSelectionCallback onSelection)
         {
             // If the output selection method is known.
             if (methodContainer.Initialised)
@@ -48,7 +48,7 @@ namespace CuttingRoom
                 if (candidates.Count > 0)
                 {
                     // Get the valid candidates based on constraints.
-                    List<NarrativeObject> validCandidates = ProcessConstraints(sequencer, constraints);
+                    List<NarrativeObject> validCandidates = ProcessConstraints(constraints);
 
                     MethodContainer.Args args = new MethodContainer.Args { onSelection = onSelection, candidates = validCandidates };
 
@@ -58,7 +58,7 @@ namespace CuttingRoom
             }
         }
 
-        public override IEnumerator Process(Sequencer sequencer, OnMultiSelectionCallback onSelection)
+        public override IEnumerator Process(OnMultiSelectionCallback onSelection)
         {
             // Not implemented
             throw new NotImplementedException("Process() not implemented for multi selection on groups.");

--- a/Assets/CuttingRoom/Scripts/MediaControllers/VideoController.cs
+++ b/Assets/CuttingRoom/Scripts/MediaControllers/VideoController.cs
@@ -168,6 +168,10 @@ namespace CuttingRoom
         /// </summary>
         public override void Unload()
         {
+            if (videoPlayer == null)
+            {
+
+            }
             videoPlayer.Stop();
             StartCoroutine(ShutdownDelay());
         }

--- a/Assets/CuttingRoom/Scripts/VariableSystem/Constraints/BoolVariableConstraint.cs
+++ b/Assets/CuttingRoom/Scripts/VariableSystem/Constraints/BoolVariableConstraint.cs
@@ -28,9 +28,9 @@ namespace CuttingRoom.VariableSystem.Constraints
 
         public override string Value => value.ToString();
 
-        public override bool Evaluate(Sequencer sequencer, NarrativeSpace narrativeSpace, NarrativeObject narrativeObject)
+        public override bool Evaluate(NarrativeSpace narrativeSpace, NarrativeObject narrativeObject)
         {
-            return Evaluate<BoolVariableConstraint, BoolVariable>(sequencer, narrativeSpace, narrativeObject, comparisonType.ToString());
+            return Evaluate<BoolVariableConstraint, BoolVariable>(narrativeSpace, narrativeObject, comparisonType.ToString());
         }
 
         public bool EqualTo(BoolVariable boolVariable)

--- a/Assets/CuttingRoom/Scripts/VariableSystem/Constraints/Constraint.cs
+++ b/Assets/CuttingRoom/Scripts/VariableSystem/Constraints/Constraint.cs
@@ -30,9 +30,9 @@ namespace CuttingRoom.VariableSystem.Constraints
 			}
 		}
 
-        public virtual bool Evaluate(Sequencer sequencer, NarrativeSpace narrativeSpace, NarrativeObject narrativeObject) { throw new NotImplementedException("Constraint must implement Evaluate() method."); }
+        public virtual bool Evaluate(NarrativeSpace narrativeSpace, NarrativeObject narrativeObject) { throw new NotImplementedException("Constraint must implement Evaluate() method."); }
 
-		protected bool Evaluate<T1, T2>(Sequencer sequencer, NarrativeSpace narrativeSpace, NarrativeObject narrativeObject, string methodName) where T1 : Constraint where T2 : Variable
+		protected bool Evaluate<T1, T2>(NarrativeSpace narrativeSpace, NarrativeObject narrativeObject, string methodName) where T1 : Constraint where T2 : Variable
 		{
 			bool resolves = false;
 
@@ -77,11 +77,7 @@ namespace CuttingRoom.VariableSystem.Constraints
 					{
 						Type parameterType = methodParameters[methodParameterCount].ParameterType;
 
-						if (parameterType == typeof(Sequencer))
-						{
-							parameters.Add(sequencer);
-						}
-						else if (parameterType == typeof(NarrativeSpace))
+						if (parameterType == typeof(NarrativeSpace))
 						{
 							parameters.Add(narrativeSpace);
 						}
@@ -111,7 +107,7 @@ namespace CuttingRoom.VariableSystem.Constraints
 				{
 					Constraint nestedConstraint = nestedConstraintQueue.Dequeue();
 
-					resolves = nestedConstraint.Evaluate(sequencer, narrativeSpace, narrativeObject);
+					resolves = nestedConstraint.Evaluate(narrativeSpace, narrativeObject);
 				}
 			}
 

--- a/Assets/CuttingRoom/Scripts/VariableSystem/Constraints/ConstraintProcessor.cs
+++ b/Assets/CuttingRoom/Scripts/VariableSystem/Constraints/ConstraintProcessor.cs
@@ -6,7 +6,7 @@ using CuttingRoom.VariableSystem.Constraints;
 
 public static class ConstraintProcessor
 {
-	public static List<NarrativeObject> Process(Sequencer sequencer, NarrativeSpace narrativeSpace, List<NarrativeObject> candidates, List<Constraint> constraints)
+	public static List<NarrativeObject> Process(NarrativeSpace narrativeSpace, List<NarrativeObject> candidates, List<Constraint> constraints)
 	{
 		// All candidates are an option to begin with.
 		List<NarrativeObject> candidatesMatchingConstraints = new List<NarrativeObject>(candidates);
@@ -21,7 +21,7 @@ public static class ConstraintProcessor
 			{
 				Constraint constraint = constraints[constraintCount];
 
-				if (!constraint.Evaluate(sequencer, narrativeSpace, candidate))
+				if (!constraint.Evaluate(narrativeSpace, candidate))
 				{
 					candidatesMatchingConstraints.Remove(candidate);
 				}
@@ -37,7 +37,7 @@ public static class ConstraintProcessor
 			{
 				Constraint candidateConstraint = candidate.constraints[candidateConstraintCount];
 
-				if (!candidateConstraint.Evaluate(sequencer, narrativeSpace, candidate))
+				if (!candidateConstraint.Evaluate(narrativeSpace, candidate))
 				{
 					candidatesMatchingConstraints.Remove(candidate);
 				}

--- a/Assets/CuttingRoom/Scripts/VariableSystem/Constraints/FloatVariableConstraint.cs
+++ b/Assets/CuttingRoom/Scripts/VariableSystem/Constraints/FloatVariableConstraint.cs
@@ -38,9 +38,9 @@ namespace CuttingRoom.VariableSystem.Constraints
 
         public override string Value => value.ToString();
 
-		public override bool Evaluate(Sequencer sequencer, NarrativeSpace narrativeSpace, NarrativeObject narrativeObject)
+		public override bool Evaluate(NarrativeSpace narrativeSpace, NarrativeObject narrativeObject)
 		{
-			return Evaluate<FloatVariableConstraint, FloatVariable>(sequencer, narrativeSpace, narrativeObject, comparisonType.ToString());
+			return Evaluate<FloatVariableConstraint, FloatVariable>(narrativeSpace, narrativeObject, comparisonType.ToString());
 		}
 
 		public bool EqualTo(FloatVariable floatVariable)

--- a/Assets/CuttingRoom/Scripts/VariableSystem/Constraints/IntVariableConstraint.cs
+++ b/Assets/CuttingRoom/Scripts/VariableSystem/Constraints/IntVariableConstraint.cs
@@ -36,9 +36,9 @@ namespace CuttingRoom.VariableSystem.Constraints
 
         public override string Value => value.ToString();
 
-		public override bool Evaluate(Sequencer sequencer, NarrativeSpace narrativeSpace, NarrativeObject narrativeObject)
+		public override bool Evaluate(NarrativeSpace narrativeSpace, NarrativeObject narrativeObject)
 		{
-			return Evaluate<IntVariableConstraint, IntVariable>(sequencer, narrativeSpace, narrativeObject, comparisonType.ToString());
+			return Evaluate<IntVariableConstraint, IntVariable>(narrativeSpace, narrativeObject, comparisonType.ToString());
 		}
 
 		public bool EqualTo(IntVariable intVariable)

--- a/Assets/CuttingRoom/Scripts/VariableSystem/Constraints/StringVariableConstraint.cs
+++ b/Assets/CuttingRoom/Scripts/VariableSystem/Constraints/StringVariableConstraint.cs
@@ -28,9 +28,9 @@ namespace CuttingRoom.VariableSystem.Constraints
 
         public override string Value => value.ToString();
 
-		public override bool Evaluate(Sequencer sequencer, NarrativeSpace narrativeSpace, NarrativeObject narrativeObject)
+		public override bool Evaluate(NarrativeSpace narrativeSpace, NarrativeObject narrativeObject)
 		{
-			return Evaluate<StringVariableConstraint, StringVariable>(sequencer, narrativeSpace, narrativeObject, comparisonType.ToString());
+			return Evaluate<StringVariableConstraint, StringVariable>(narrativeSpace, narrativeObject, comparisonType.ToString());
 		}
 
 		public bool EqualTo(StringVariable stringVariable)

--- a/Assets/CuttingRoom/Scripts/VariableSystem/Constraints/TagVariableConstraint.cs
+++ b/Assets/CuttingRoom/Scripts/VariableSystem/Constraints/TagVariableConstraint.cs
@@ -27,7 +27,7 @@ namespace CuttingRoom.VariableSystem.Constraints
 
         public override string Value => value;
 
-		public override bool Evaluate(Sequencer sequencer, NarrativeSpace narrativeSpace, NarrativeObject narrativeObject)
+		public override bool Evaluate(NarrativeSpace narrativeSpace, NarrativeObject narrativeObject)
 		{
 			if (narrativeObject != null && narrativeObject.VariableStore != null)
 			{
@@ -36,7 +36,7 @@ namespace CuttingRoom.VariableSystem.Constraints
 
 			if (tagVariable != null)
 			{
-				return Evaluate<TagVariableConstraint, Variable>(sequencer, narrativeSpace, narrativeObject, comparisonType.ToString());
+				return Evaluate<TagVariableConstraint, Variable>(narrativeSpace, narrativeObject, comparisonType.ToString());
 			}
 			else
 			{

--- a/Assets/Editor/CuttingRoomEditor/CuttingRoomContextMenus.cs
+++ b/Assets/Editor/CuttingRoomEditor/CuttingRoomContextMenus.cs
@@ -11,15 +11,6 @@ namespace CuttingRoom.Editor
 	{
 		private const int menuItemPriority = 0;
 
-		//[MenuItem("Cutting Room/Scene Utilities/Set All Atomic Narrative Object Durations To Length Of Media Source")]
-		//public static void SetAllAtomsDurationToMediaLength()
-		//{
-		//	if (EditorUtility.DisplayDialog("Warning", "Are you sure you want to set all Atomic Narrative Objects to the length of their assigned Media Source?", "Yes", "Cancel"))
-		//	{
-		//		CuttingRoomUtilities.SetAllSceneAtomsDurationToMediaLength();
-		//	}
-		//}
-
 		[MenuItem("GameObject/Cutting Room/Create/Narrative Space", false, menuItemPriority)]
 		public static NarrativeSpace CreateNarrativeSpace()
 		{
@@ -27,21 +18,6 @@ namespace CuttingRoom.Editor
 
 			return narrativeSpace;
 		}
-
-		//public static Sequencer CreateSequencer()
-		//{
-		//	Sequencer sequencer = new GameObject("Sequencer", typeof(Sequencer)).GetComponent<Sequencer>();
-
-		//	// Find narrative space and try to link it to the sequencer.
-		//	NarrativeSpace narrativeSpace = GameObject.FindObjectOfType<NarrativeSpace>();
-
-		//	if (narrativeSpace != null)
-		//	{
-		//		sequencer.NarrativeSpace = narrativeSpace;
-		//	}
-
-		//	return sequencer;
-		//}
 
 		public static AtomicNarrativeObject InstantiateAtomicNarrativeObject()
 		{
@@ -158,40 +134,5 @@ namespace CuttingRoom.Editor
 			// Ping the object to ensure it is visible in hierarchy (unfolded).
 			EditorGUIUtility.PingObject(gameObject);
 		}
-
-		//[MenuItem("CONTEXT/AtomicNarrativeObject/Set Duration To Length of MediaSource")]
-		//public static async void SetDurationToLengthOfMediaSource(MenuCommand command)
-		//{
-		//	AtomicNarrativeObject atomicNarrativeObject = (AtomicNarrativeObject)command.context;
-
-		//	if (atomicNarrativeObject.mediaSource != null)
-		//	{
-		//		MediaController mediaController = atomicNarrativeObject.mediaSource.mediaControllerPrefab.GetComponent<MediaController>();
-
-		//		float duration = 0.0f;
-
-		//		// Try to get the duration. If the controller has not overriden the GetDuration method, task returned is null so duration is undefined. Set to 0.0f.
-		//		Task<float> getDurationTask = mediaController.GetDuration(atomicNarrativeObject.mediaSource);
-
-		//		if (getDurationTask != null)
-		//		{
-		//			duration = await getDurationTask;
-		//		}
-		//		else
-		//		{
-		//			Debug.Log("Controller has provided an implementation of the GetDuration method. Duration is defaulting to 0.0f.");
-		//		}
-
-		//		atomicNarrativeObject.duration = duration;
-
-		//		EditorUtility.SetDirty(atomicNarrativeObject);
-		//	}
-		//	else
-		//	{
-		//		atomicNarrativeObject.duration = 0.0f;
-
-		//		EditorUtility.SetDirty(atomicNarrativeObject);
-		//	}
-		//}
 	}
 }

--- a/Assets/Editor/CuttingRoomEditor/CuttingRoomContextMenus.cs
+++ b/Assets/Editor/CuttingRoomEditor/CuttingRoomContextMenus.cs
@@ -28,20 +28,20 @@ namespace CuttingRoom.Editor
 			return narrativeSpace;
 		}
 
-		public static Sequencer CreateSequencer()
-		{
-			Sequencer sequencer = new GameObject("Sequencer", typeof(Sequencer)).GetComponent<Sequencer>();
+		//public static Sequencer CreateSequencer()
+		//{
+		//	Sequencer sequencer = new GameObject("Sequencer", typeof(Sequencer)).GetComponent<Sequencer>();
 
-			// Find narrative space and try to link it to the sequencer.
-			NarrativeSpace narrativeSpace = GameObject.FindObjectOfType<NarrativeSpace>();
+		//	// Find narrative space and try to link it to the sequencer.
+		//	NarrativeSpace narrativeSpace = GameObject.FindObjectOfType<NarrativeSpace>();
 
-			if (narrativeSpace != null)
-			{
-				sequencer.NarrativeSpace = narrativeSpace;
-			}
+		//	if (narrativeSpace != null)
+		//	{
+		//		sequencer.NarrativeSpace = narrativeSpace;
+		//	}
 
-			return sequencer;
-		}
+		//	return sequencer;
+		//}
 
 		public static AtomicNarrativeObject InstantiateAtomicNarrativeObject()
 		{

--- a/Assets/Editor/CuttingRoomEditor/Nodes/AtomicNarrativeObjectNode.cs
+++ b/Assets/Editor/CuttingRoomEditor/Nodes/AtomicNarrativeObjectNode.cs
@@ -123,7 +123,7 @@ namespace CuttingRoom.Editor
             if (contentType == MediaController.ContentTypeEnum.Video)
             {
                 // Find the sequencer.
-                Sequencer sequencer = UnityEngine.Object.FindObjectOfType<Sequencer>();
+                Sequencer sequencer = UnityEngine.Object.FindObjectOfType<NarrativeSpace>().Sequencer;
 
                 VideoController videoController = AtomicNarrativeObject.MediaController as VideoController;
                 if (videoController != null)
@@ -242,7 +242,7 @@ namespace CuttingRoom.Editor
                     VariableStore targetVariableStore = null;
 
                     // Find the sequencer.
-                    Sequencer sequencer = UnityEngine.Object.FindObjectOfType<Sequencer>();
+                    Sequencer sequencer = UnityEngine.Object.FindObjectOfType<NarrativeSpace>().Sequencer;
 
                     if (sequencer != null && sequencer.NarrativeSpace != null && !sequencer.NarrativeSpace.UnlockAdvancedFeatures)
                     {

--- a/Assets/Editor/CuttingRoomEditor/Nodes/AtomicNarrativeObjectNode.cs
+++ b/Assets/Editor/CuttingRoomEditor/Nodes/AtomicNarrativeObjectNode.cs
@@ -123,12 +123,12 @@ namespace CuttingRoom.Editor
             if (contentType == MediaController.ContentTypeEnum.Video)
             {
                 // Find the sequencer.
-                Sequencer sequencer = UnityEngine.Object.FindObjectOfType<NarrativeSpace>().Sequencer;
+                NarrativeSpace narrativeSpace = UnityEngine.Object.FindObjectOfType<NarrativeSpace>();
 
                 VideoController videoController = AtomicNarrativeObject.MediaController as VideoController;
                 if (videoController != null)
                 {
-                    if (sequencer != null && (sequencer.NarrativeSpace.UnlockAdvancedFeatures || videoController.sourceLocation != VideoController.SourceLocation.VideoClip))
+                    if (narrativeSpace != null && (narrativeSpace.UnlockAdvancedFeatures || videoController.sourceLocation != VideoController.SourceLocation.VideoClip))
                     {
                         // Set video source type
                         VisualElement videoSourcePicker = UIElementsUtils.CreateEnumFieldRow("Video Source Type", videoController.sourceLocation, (newValue) =>
@@ -241,10 +241,10 @@ namespace CuttingRoom.Editor
                     VariableSetter variableSetter = buttonController.variableSetter;
                     VariableStore targetVariableStore = null;
 
-                    // Find the sequencer.
-                    Sequencer sequencer = UnityEngine.Object.FindObjectOfType<NarrativeSpace>().Sequencer;
+                    // Find the narrative space.
+                    NarrativeSpace narrativeSpace = UnityEngine.Object.FindObjectOfType<NarrativeSpace>();
 
-                    if (sequencer != null && sequencer.NarrativeSpace != null && !sequencer.NarrativeSpace.UnlockAdvancedFeatures)
+                    if (narrativeSpace != null && !narrativeSpace.UnlockAdvancedFeatures)
                     {
                         // Force only global variable without advance feature unlock
                         variableSetter.variableStoreLocation = VariableStoreLocation.Global;
@@ -254,9 +254,9 @@ namespace CuttingRoom.Editor
                     switch (variableSetter.variableStoreLocation)
                     {
                         case VariableStoreLocation.Global:
-                            if (sequencer != null && sequencer.NarrativeSpace != null)
+                            if (narrativeSpace != null)
                             {
-                                targetVariableStore = sequencer.NarrativeSpace.GlobalVariableStore;
+                                targetVariableStore = narrativeSpace.GlobalVariableStore;
                             }
                             break;
 
@@ -268,7 +268,7 @@ namespace CuttingRoom.Editor
                             break;
                     }
 
-                    if (sequencer != null && sequencer.NarrativeSpace != null && sequencer.NarrativeSpace.UnlockAdvancedFeatures)
+                    if (narrativeSpace != null && narrativeSpace.UnlockAdvancedFeatures)
                     {
                         // Variable Location
                         VisualElement variableStoreLocationEnumField = UIElementsUtils.CreateEnumFieldRow("Button Variable Location", variableSetter.variableStoreLocation, (newValue) =>

--- a/Assets/Editor/CuttingRoomEditor/Nodes/NarrativeObjectNode.cs
+++ b/Assets/Editor/CuttingRoomEditor/Nodes/NarrativeObjectNode.cs
@@ -381,7 +381,7 @@ namespace CuttingRoom.Editor
                             Variable targetVariable = null;
 
                             // Find the sequencer.
-                            Sequencer sequencer = UnityEngine.Object.FindObjectOfType<Sequencer>();
+                            Sequencer sequencer = UnityEngine.Object.FindObjectOfType<NarrativeSpace>().Sequencer;
 
                             if (sequencer != null && sequencer.NarrativeSpace != null && !sequencer.NarrativeSpace.UnlockAdvancedFeatures)
                             {
@@ -660,9 +660,9 @@ namespace CuttingRoom.Editor
 
 
                 // Find the sequencer.
-                Sequencer sequencer = UnityEngine.Object.FindObjectOfType<Sequencer>();
+                NarrativeSpace narrativeSpace = UnityEngine.Object.FindObjectOfType<NarrativeSpace>();
 
-                if (sequencer != null && sequencer.NarrativeSpace != null && !sequencer.NarrativeSpace.UnlockAdvancedFeatures)
+                if (narrativeSpace != null && !narrativeSpace.UnlockAdvancedFeatures)
                 {
                     // Force only global variable without advance feature unlock
                     constraint.variableStoreLocation = VariableStoreLocation.Global;
@@ -676,9 +676,9 @@ namespace CuttingRoom.Editor
                     switch (constraint.variableStoreLocation)
                     {
                         case VariableStoreLocation.Global:
-                            if (sequencer != null && sequencer.NarrativeSpace != null)
+                            if (narrativeSpace != null)
                             {
-                                targetVariableStore = sequencer.NarrativeSpace.GlobalVariableStore;
+                                targetVariableStore = narrativeSpace.GlobalVariableStore;
                             }
                             break;
 
@@ -691,7 +691,7 @@ namespace CuttingRoom.Editor
                     }
                 }
 
-                if (sequencer != null && sequencer.NarrativeSpace != null && sequencer.NarrativeSpace.UnlockAdvancedFeatures)
+                if (narrativeSpace != null && narrativeSpace.UnlockAdvancedFeatures)
                 {
                     // Variable Location
                     VisualElement varLocationRow = UIElementsUtils.GetRowContainer();

--- a/Assets/Editor/CuttingRoomEditor/Nodes/NarrativeObjectNode.cs
+++ b/Assets/Editor/CuttingRoomEditor/Nodes/NarrativeObjectNode.cs
@@ -381,9 +381,9 @@ namespace CuttingRoom.Editor
                             Variable targetVariable = null;
 
                             // Find the sequencer.
-                            Sequencer sequencer = UnityEngine.Object.FindObjectOfType<NarrativeSpace>().Sequencer;
+                            NarrativeSpace narrativeSpace = UnityEngine.Object.FindObjectOfType<NarrativeSpace>();
 
-                            if (sequencer != null && sequencer.NarrativeSpace != null && !sequencer.NarrativeSpace.UnlockAdvancedFeatures)
+                            if (narrativeSpace != null && !narrativeSpace.UnlockAdvancedFeatures)
                             {
                                 // Force only global variable without advance feature unlock
                                 variableProcessingTrigger.VariableLocation = VariableStoreLocation.Global;
@@ -393,9 +393,9 @@ namespace CuttingRoom.Editor
                             switch (variableProcessingTrigger.VariableLocation)
                             {
                                 case VariableStoreLocation.Global:
-                                    if (sequencer != null && sequencer.NarrativeSpace != null)
+                                    if (narrativeSpace != null)
                                     {
-                                        targetVariableStore = sequencer.NarrativeSpace.GlobalVariableStore;
+                                        targetVariableStore = narrativeSpace.GlobalVariableStore;
                                     }
                                     break;
 
@@ -428,7 +428,7 @@ namespace CuttingRoom.Editor
                             processingTriggerRow.Add(variableTriggerRow);
 
                             // Variable Location
-                            if (sequencer != null && sequencer.NarrativeSpace != null && sequencer.NarrativeSpace.UnlockAdvancedFeatures)
+                            if (narrativeSpace != null && narrativeSpace.UnlockAdvancedFeatures)
                             {
                                 VisualElement variableLocationRow = UIElementsUtils.GetRowContainer();
                                 variableLocationRow.styleSheets.Add(StyleSheet);

--- a/Assets/Editor/CuttingRoomEditor/Utils/CuttingRoomEditorUtils.cs
+++ b/Assets/Editor/CuttingRoomEditor/Utils/CuttingRoomEditorUtils.cs
@@ -18,15 +18,15 @@ namespace CuttingRoom.Editor
             }
 
             // Ensure sequencer exists.
-            Sequencer sequencer = Object.FindObjectOfType<Sequencer>();
+            //Sequencer sequencer = Object.FindObjectOfType<Sequencer>();
 
-            if (sequencer == null)
-            {
-                sequencer = CuttingRoomContextMenus.CreateSequencer();
+            //if (sequencer == null)
+            //{
+            //    sequencer = CuttingRoomContextMenus.CreateSequencer();
 
-                // Set narrative space on the sequencer.
-                sequencer.NarrativeSpace = narrativeSpace;
-            }
+            //    // Set narrative space on the sequencer.
+            //    sequencer.NarrativeSpace = narrativeSpace;
+            //}
 
             return narrativeSpace;
         }

--- a/Assets/Resources/CuttingRoomEditor/GroupNarrative.asset
+++ b/Assets/Resources/CuttingRoomEditor/GroupNarrative.asset
@@ -26,9 +26,6 @@ MonoBehaviour:
     narrativeObjectNodeGuids:
     - 6a2495cb-d16f-4950-b6a1-a3044532eeb8
     - 44effc51-e3ce-4cfe-928d-da3d82bfed4f
-    - 31440e4f-9ef3-40ab-9a05-89212f179a67
-    - 2d0a3d05-8a4c-476f-8c7b-101bebfdca24
-    - 2cde4d88-818f-4028-980d-9c8b781d6bf5
   - narrativeObjectGuid: 44effc51-e3ce-4cfe-928d-da3d82bfed4f
     narrativeObjectNodeGuids:
     - 93bffa62-7f66-4737-85b0-e5f8bb1556c6

--- a/Assets/Resources/CuttingRoomEditor/TimedNarrative.asset
+++ b/Assets/Resources/CuttingRoomEditor/TimedNarrative.asset
@@ -22,8 +22,6 @@ MonoBehaviour:
   viewContainerStates:
   - narrativeObjectGuid: 0
     narrativeObjectNodeGuids:
-    - 6a2495cb-d16f-4950-b6a1-a3044532eeb8
-    - 44effc51-e3ce-4cfe-928d-da3d82bfed4f
     - 31440e4f-9ef3-40ab-9a05-89212f179a67
     - 2d0a3d05-8a4c-476f-8c7b-101bebfdca24
     - 2cde4d88-818f-4028-980d-9c8b781d6bf5

--- a/Assets/Resources/CuttingRoomEditor/VariableNarrative.asset
+++ b/Assets/Resources/CuttingRoomEditor/VariableNarrative.asset
@@ -25,5 +25,20 @@ MonoBehaviour:
     - b490e06d-c3d3-4e29-bf1b-1d38e551cc7b
     - abcd84de-e790-4372-8d20-f4d328211c0b
     - df25f675-2b54-46d5-ad12-aed5745fe27c
+  - narrativeObjectGuid: f1395552-c098-40f5-9656-a21a5f14c71e
+    narrativeObjectNodeGuids:
+    - 58f7e25e-38cd-4511-9015-fe6497a8366f
+    - 5c6b3977-26df-4e11-a900-2d52b88878c7
+    - 728eeafd-4ccd-4fcf-a56f-72e3676bc3f4
+  - narrativeObjectGuid: a5ed8bd6-36b7-4ccc-9814-6a5caa9bcff0
+    narrativeObjectNodeGuids:
+    - 2537d322-9ddf-48f6-959b-f10393847a84
+    - f8d958bf-99b0-4029-84af-b0fe51e51367
+    - 5b7d1dd5-7b87-4e0b-9751-7a06c7ebde18
+  - narrativeObjectGuid: e16efe50-3b94-40fd-9f93-fb25e0f2f4b5
+    narrativeObjectNodeGuids:
+    - 987d59ef-3147-4239-8db7-c7623ceb119b
+    - 02139cb5-d6c6-4d11-a399-c7a87e7cdb77
+    - 51c85242-67c8-4b37-8223-0d0cf340054b
   viewContainerStackGuids:
   - 0

--- a/Assets/Resources/CuttingRoomEditor/VideoNarrative.asset
+++ b/Assets/Resources/CuttingRoomEditor/VideoNarrative.asset
@@ -34,7 +34,7 @@ MonoBehaviour:
   - narrativeObjectGuid: 8f8ebc9d-7ea7-4438-9aff-8da513d26762
     position: {x: 901, y: 305}
   - narrativeObjectGuid: e0e2011d-fbfd-4079-a002-cded5d4b6ba7
-    position: {x: 901, y: 127}
+    position: {x: 901, y: 125}
   - narrativeObjectGuid: 2537d322-9ddf-48f6-959b-f10393847a84
     position: {x: 826, y: -12}
   - narrativeObjectGuid: f8d958bf-99b0-4029-84af-b0fe51e51367
@@ -50,9 +50,6 @@ MonoBehaviour:
   viewContainerStates:
   - narrativeObjectGuid: 0
     narrativeObjectNodeGuids:
-    - b490e06d-c3d3-4e29-bf1b-1d38e551cc7b
-    - abcd84de-e790-4372-8d20-f4d328211c0b
-    - df25f675-2b54-46d5-ad12-aed5745fe27c
     - 06b5b2ab-b71b-4009-b450-3dc6870491ce
     - c91fec49-478e-4276-a06b-4c65af7db260
     - f1395552-c098-40f5-9656-a21a5f14c71e

--- a/Assets/Resources/CuttingRoomEditor/VideoNarrative.asset
+++ b/Assets/Resources/CuttingRoomEditor/VideoNarrative.asset
@@ -47,11 +47,27 @@ MonoBehaviour:
     position: {x: 809, y: 167}
   - narrativeObjectGuid: 51c85242-67c8-4b37-8223-0d0cf340054b
     position: {x: 809, y: 316}
+  - narrativeObjectGuid: c446a44a-c5f7-4993-8ea0-62729730df12
+    position: {x: 800, y: 491}
+  - narrativeObjectGuid: 94fa40ae-f1b3-40d0-bf5b-c041b329e12b
+    position: {x: 819, y: 326}
+  - narrativeObjectGuid: 7682bee6-3d33-4705-8ce5-6c86f23cd3d3
+    position: {x: 819, y: 326}
+  - narrativeObjectGuid: 8fd85a41-9f67-40c7-b54d-47e7bbed9187
+    position: {x: 208, y: 456}
+  - narrativeObjectGuid: 65ab60bd-b6e1-48d3-a2e0-76b1fb4ef852
+    position: {x: 283, y: 409}
+  - narrativeObjectGuid: 6fdf1960-ab9b-4152-8173-669a6a1733c2
+    position: {x: 675, y: 229}
+  - narrativeObjectGuid: e8c95535-8821-47d0-9021-ce23f91235e7
+    position: {x: 675, y: 393}
+  - narrativeObjectGuid: d1d60210-8110-4699-a4e6-37e004550951
+    position: {x: 523, y: 350}
+  - narrativeObjectGuid: 32018dca-2d98-4a44-bb99-17d244b2beef
+    position: {x: 479, y: 388}
   viewContainerStates:
   - narrativeObjectGuid: 0
     narrativeObjectNodeGuids:
-    - 6a2495cb-d16f-4950-b6a1-a3044532eeb8
-    - 44effc51-e3ce-4cfe-928d-da3d82bfed4f
     - 06b5b2ab-b71b-4009-b450-3dc6870491ce
     - c91fec49-478e-4276-a06b-4c65af7db260
     - f1395552-c098-40f5-9656-a21a5f14c71e
@@ -85,5 +101,9 @@ MonoBehaviour:
     narrativeObjectNodeGuids:
     - 2012dce6-2632-49af-9391-215550a4ffe8
     - 022aa23b-4f5f-4129-808b-e5a836b59ceb
+  - narrativeObjectGuid: c446a44a-c5f7-4993-8ea0-62729730df12
+    narrativeObjectNodeGuids:
+    - 6fdf1960-ab9b-4152-8173-669a6a1733c2
+    - e8c95535-8821-47d0-9021-ce23f91235e7
   viewContainerStackGuids:
   - 0

--- a/Assets/Resources/CuttingRoomEditor/VideoNarrative.asset
+++ b/Assets/Resources/CuttingRoomEditor/VideoNarrative.asset
@@ -50,6 +50,8 @@ MonoBehaviour:
   viewContainerStates:
   - narrativeObjectGuid: 0
     narrativeObjectNodeGuids:
+    - 6a2495cb-d16f-4950-b6a1-a3044532eeb8
+    - 44effc51-e3ce-4cfe-928d-da3d82bfed4f
     - 06b5b2ab-b71b-4009-b450-3dc6870491ce
     - c91fec49-478e-4276-a06b-4c65af7db260
     - f1395552-c098-40f5-9656-a21a5f14c71e
@@ -75,5 +77,13 @@ MonoBehaviour:
     - 987d59ef-3147-4239-8db7-c7623ceb119b
     - 02139cb5-d6c6-4d11-a399-c7a87e7cdb77
     - 51c85242-67c8-4b37-8223-0d0cf340054b
+  - narrativeObjectGuid: ea19580d-cf21-4388-9dc4-c2f871889a86
+    narrativeObjectNodeGuids:
+    - 58b54b3e-9c11-4fa8-9f64-63bb17a9f44b
+    - fd7e95b0-7cb5-4d52-8b2e-b0c9f96f77ec
+  - narrativeObjectGuid: c21edd03-764e-468c-88d6-570f5e24372a
+    narrativeObjectNodeGuids:
+    - 2012dce6-2632-49af-9391-215550a4ffe8
+    - 022aa23b-4f5f-4129-808b-e5a836b59ceb
   viewContainerStackGuids:
   - 0

--- a/Assets/Samples/Advanced/Gaming/GroupNarrative/GroupNarrative.unity
+++ b/Assets/Samples/Advanced/Gaming/GroupNarrative/GroupNarrative.unity
@@ -153,7 +153,7 @@ Transform:
   m_Children:
   - {fileID: 910536143}
   m_Father: {fileID: 0}
-  m_RootOrder: 3
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &77273043
 GameObject:
@@ -515,52 +515,6 @@ MonoBehaviour:
   guid: c2605eed-db30-44bb-b82e-b730bf482afd
   defaultValue: 0
   value: 0
---- !u!1 &780995879
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 780995881}
-  - component: {fileID: 780995880}
-  m_Layer: 0
-  m_Name: Sequencer
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &780995880
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 780995879}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ea03c035a0122ed4db71001266a7761d, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  narrativeSpace: {fileID: 1463240304}
-  autoStartProcessing: 1
---- !u!4 &780995881
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 780995879}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &905866573
 GameObject:
   m_ObjectHideFlags: 0
@@ -828,7 +782,7 @@ Transform:
   - {fileID: 277655715}
   - {fileID: 776102889}
   m_Father: {fileID: 0}
-  m_RootOrder: 2
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1463240306
 MonoBehaviour:
@@ -844,7 +798,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   autoAddVariablesOnGameObject: 1
   variableList:
-  - {fileID: 0}
   - {fileID: 1463240308}
   - {fileID: 1463240310}
   - {fileID: 1463240309}
@@ -1052,7 +1005,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3303852136968092877, guid: 6b9d64c320828424fadb4c589207982c, type: 3}
       propertyPath: m_RootOrder
-      value: 4
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 3303852136968092877, guid: 6b9d64c320828424fadb4c589207982c, type: 3}
       propertyPath: m_LocalPosition.x

--- a/Assets/Samples/Advanced/Gaming/TimedNarrative/TimedNarrative.unity
+++ b/Assets/Samples/Advanced/Gaming/TimedNarrative/TimedNarrative.unity
@@ -152,7 +152,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 4
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &77273043
 GameObject:
@@ -262,6 +262,7 @@ GameObject:
   - component: {fileID: 277655716}
   - component: {fileID: 277655717}
   - component: {fileID: 277655718}
+  - component: {fileID: 277655719}
   m_Layer: 0
   m_Name: 1.0
   m_TagString: Untagged
@@ -351,7 +352,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   autoAddVariablesOnGameObject: 1
-  variableList: []
+  variableList:
+  - {fileID: 277655719}
 --- !u!114 &277655718
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -366,52 +368,23 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   gameObjects:
   - {fileID: 8347624901840340941, guid: 48c14047b9eee65488414c0098eab727, type: 3}
---- !u!1 &780995879
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 780995881}
-  - component: {fileID: 780995880}
-  m_Layer: 0
-  m_Name: Sequencer
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &780995880
+--- !u!114 &277655719
 MonoBehaviour:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 780995879}
+  m_GameObject: {fileID: 277655712}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ea03c035a0122ed4db71001266a7761d, type: 3}
+  m_Script: {fileID: 11500000, guid: e132dfbb23143e0488b028cbecfc1c6d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  narrativeSpace: {fileID: 1463240304}
-  autoStartProcessing: 1
---- !u!4 &780995881
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 780995879}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 2
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  variableCategory: 1
+  variableName: hasPlayed
+  guid: 34fcf95b-3b57-408e-bd85-69a349fb35b1
+  defaultValue: 0
+  value: 0
 --- !u!1 &1367962896
 GameObject:
   m_ObjectHideFlags: 0
@@ -426,6 +399,7 @@ GameObject:
   - component: {fileID: 1367962898}
   - component: {fileID: 1367962901}
   - component: {fileID: 1367962902}
+  - component: {fileID: 1367962903}
   m_Layer: 0
   m_Name: 2.2
   m_TagString: Untagged
@@ -514,7 +488,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   autoAddVariablesOnGameObject: 1
-  variableList: []
+  variableList:
+  - {fileID: 1367962903}
 --- !u!114 &1367962902
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -529,6 +504,23 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   gameObjects:
   - {fileID: 5018205221012154495, guid: dc47d873ccf860041a4d2bd642797774, type: 3}
+--- !u!114 &1367962903
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1367962896}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e132dfbb23143e0488b028cbecfc1c6d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  variableCategory: 1
+  variableName: hasPlayed
+  guid: 398b8b87-6f1f-4d97-8087-dd1b1e6a23dc
+  defaultValue: 0
+  value: 0
 --- !u!1 &1463240303
 GameObject:
   m_ObjectHideFlags: 0
@@ -540,6 +532,8 @@ GameObject:
   - component: {fileID: 1463240305}
   - component: {fileID: 1463240304}
   - component: {fileID: 1463240306}
+  - component: {fileID: 1463240308}
+  - component: {fileID: 1463240307}
   m_Layer: 0
   m_Name: NarrativeSpace
   m_TagString: Untagged
@@ -560,6 +554,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   rootNarrativeObject: {fileID: 277655713}
+  unlockAdvancedFeatures: 0
   globalVariableStore: {fileID: 1463240306}
 --- !u!4 &1463240305
 Transform:
@@ -577,7 +572,7 @@ Transform:
   - {fileID: 1960273035}
   - {fileID: 1367962900}
   m_Father: {fileID: 0}
-  m_RootOrder: 3
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1463240306
 MonoBehaviour:
@@ -592,7 +587,43 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   autoAddVariablesOnGameObject: 1
-  variableList: []
+  variableList:
+  - {fileID: 1463240308}
+  - {fileID: 1463240307}
+--- !u!114 &1463240307
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1463240303}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e132dfbb23143e0488b028cbecfc1c6d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  variableCategory: 1
+  variableName: FALSE
+  guid: 27980db1-2418-41ae-af82-89f9ad4756bd
+  defaultValue: 0
+  value: 0
+--- !u!114 &1463240308
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1463240303}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e132dfbb23143e0488b028cbecfc1c6d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  variableCategory: 1
+  variableName: TRUE
+  guid: 4c0e1e8c-b96d-484d-b296-0d3f0f241c30
+  defaultValue: 1
+  value: 1
 --- !u!1 &1928124806
 GameObject:
   m_ObjectHideFlags: 0
@@ -691,6 +722,7 @@ GameObject:
   - component: {fileID: 1960273033}
   - component: {fileID: 1960273036}
   - component: {fileID: 1960273037}
+  - component: {fileID: 1960273038}
   m_Layer: 0
   m_Name: 2.1
   m_TagString: Untagged
@@ -779,7 +811,8 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   autoAddVariablesOnGameObject: 1
-  variableList: []
+  variableList:
+  - {fileID: 1960273038}
 --- !u!114 &1960273037
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -794,3 +827,20 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   gameObjects:
   - {fileID: 7986207238012258351, guid: 055952a58a3b14f4faf8e56690607124, type: 3}
+--- !u!114 &1960273038
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1960273031}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e132dfbb23143e0488b028cbecfc1c6d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  variableCategory: 1
+  variableName: hasPlayed
+  guid: 44578a62-b149-4cbd-a96e-db43d39b9fc4
+  defaultValue: 0
+  value: 0

--- a/Assets/Samples/Advanced/Gaming/VariableNarrative/VariableNarrative.unity
+++ b/Assets/Samples/Advanced/Gaming/VariableNarrative/VariableNarrative.unity
@@ -153,7 +153,7 @@ Transform:
   m_Children:
   - {fileID: 910536143}
   m_Father: {fileID: 0}
-  m_RootOrder: 3
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &77273043
 GameObject:
@@ -389,52 +389,6 @@ MonoBehaviour:
   guid: 36b53624-562b-4966-bb6b-b2854f7f5bef
   defaultValue: 0
   value: 0
---- !u!1 &780995879
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 780995881}
-  - component: {fileID: 780995880}
-  m_Layer: 0
-  m_Name: Sequencer
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &780995880
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 780995879}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ea03c035a0122ed4db71001266a7761d, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  narrativeSpace: {fileID: 1463240304}
-  autoStartProcessing: 1
---- !u!4 &780995881
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 780995879}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 1
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &910536142
 GameObject:
   m_ObjectHideFlags: 0
@@ -722,7 +676,7 @@ Transform:
   - {fileID: 1960273035}
   - {fileID: 1367962900}
   m_Father: {fileID: 0}
-  m_RootOrder: 2
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1463240306
 MonoBehaviour:
@@ -943,7 +897,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3303852136968092877, guid: 6b9d64c320828424fadb4c589207982c, type: 3}
       propertyPath: m_RootOrder
-      value: 4
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 3303852136968092877, guid: 6b9d64c320828424fadb4c589207982c, type: 3}
       propertyPath: m_LocalPosition.x

--- a/Assets/Samples/VideoNarrative/VideoNarrative.unity
+++ b/Assets/Samples/VideoNarrative/VideoNarrative.unity
@@ -136,6 +136,8 @@ GameObject:
   - component: {fileID: 2263671}
   - component: {fileID: 2263675}
   - component: {fileID: 2263674}
+  - component: {fileID: 2263677}
+  - component: {fileID: 2263676}
   m_Layer: 0
   m_Name: NarrativeSpace
   m_TagString: Untagged
@@ -174,6 +176,8 @@ MonoBehaviour:
   variableList:
   - {fileID: 2263675}
   - {fileID: 2263674}
+  - {fileID: 2263677}
+  - {fileID: 2263676}
 --- !u!4 &2263673
 Transform:
   m_ObjectHideFlags: 0
@@ -223,6 +227,40 @@ MonoBehaviour:
   guid: ec0e4437-cff6-47a4-a4f0-30f5805b1716
   defaultValue: A
   value: A
+--- !u!114 &2263676
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2263670}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e132dfbb23143e0488b028cbecfc1c6d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  variableCategory: 1
+  variableName: FALSE
+  guid: 331fc121-858b-4d97-b43c-9aaeaf4ec166
+  defaultValue: 0
+  value: 0
+--- !u!114 &2263677
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2263670}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: e132dfbb23143e0488b028cbecfc1c6d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  variableCategory: 1
+  variableName: TRUE
+  guid: e8cd4d2b-8c96-498e-8b7f-969c6c8380bc
+  defaultValue: 1
+  value: 1
 --- !u!1 &6897881
 GameObject:
   m_ObjectHideFlags: 0
@@ -473,7 +511,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 10
+  m_RootOrder: 9
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &10034511
 GameObject:
@@ -564,7 +602,7 @@ Transform:
   - {fileID: 1114946516}
   - {fileID: 951450585}
   m_Father: {fileID: 0}
-  m_RootOrder: 6
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &10034516
 MonoBehaviour:
@@ -705,7 +743,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 4
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &118441150
 MonoBehaviour:
@@ -1150,52 +1188,6 @@ MonoBehaviour:
   guid: 5276e110-a633-4398-8e3c-72a5ccc2009b
   defaultValue: 0
   value: 0
---- !u!1 &767232968
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 767232970}
-  - component: {fileID: 767232969}
-  m_Layer: 0
-  m_Name: Sequencer
-  m_TagString: Untagged
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!114 &767232969
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 767232968}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: ea03c035a0122ed4db71001266a7761d, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  narrativeSpace: {fileID: 2263671}
-  autoStartProcessing: 1
---- !u!4 &767232970
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 767232968}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
-  m_LocalScale: {x: 1, y: 1, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 0}
-  m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &847789830
 GameObject:
   m_ObjectHideFlags: 0
@@ -1329,7 +1321,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 7
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &847789839
 MonoBehaviour:
@@ -1478,7 +1470,7 @@ Transform:
   - {fileID: 358956550}
   - {fileID: 1904346692}
   m_Father: {fileID: 0}
-  m_RootOrder: 9
+  m_RootOrder: 8
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &871223313
 MonoBehaviour:
@@ -2060,7 +2052,7 @@ Transform:
   - {fileID: 882382008}
   - {fileID: 505902134}
   m_Father: {fileID: 0}
-  m_RootOrder: 8
+  m_RootOrder: 7
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1076746257
 MonoBehaviour:
@@ -2769,7 +2761,7 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children: []
   m_Father: {fileID: 0}
-  m_RootOrder: 5
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &1615880547
 MonoBehaviour:


### PR DESCRIPTION
Sequencer was nesting coroutines so that preceding narrative objects were waiting on the next one meaning they never really ended. Has been reworked so that sequencer itself drives sequencing. Separate sequencers are created to handle "sub"-sequences, such as groups, layers and graphs. Current state and history are maintained globally for all sequncers.